### PR TITLE
Fix #2

### DIFF
--- a/huelloween.py
+++ b/huelloween.py
@@ -196,7 +196,7 @@ def hued_wav_file(sound_file: str, bridge: Bridge, light: Light):
 
 def load_config():
     with open("config.yml", "r") as ymlfile:
-        cfg = yaml.load(ymlfile)
+        cfg = yaml.safe_load(ymlfile)
     return cfg
 
 


### PR DESCRIPTION
safe_load() appears to be sufficient for loading the config, and avoids deprecation then change to load() in versions of PyYAML >=3.11. (Also appears to work in 3.11, so not updating requirements.txt here.)